### PR TITLE
Bug Fixes #20

### DIFF
--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -213,7 +213,7 @@ class BlockForm extends Component {
 								name="customTimer"
 								placeholder="Time in mins"
 								type="number"
-                                min="0"
+                                min="1"
 								value={this.state.customTimer}
 								onChange={this.handleChange}
 							/>

--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -213,6 +213,7 @@ class BlockForm extends Component {
 								name="customTimer"
 								placeholder="Time in mins"
 								type="number"
+                                min="0"
 								value={this.state.customTimer}
 								onChange={this.handleChange}
 							/>

--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -127,8 +127,9 @@ class BlockForm extends Component {
 
 		switch (event.target.name) {
 			case 'title':
-				let titleLen = event.target.value.length;
-				titleValid = titleLen > 0 ? 'valid' : 'Title cannot be empty';
+				let title = event.target.value;
+                const EMPTY_FIELD_CHECK = title.trim() === "";
+				titleValid = !EMPTY_FIELD_CHECK ?  'valid' : 'Title cannot be empty';
 				break;
 			case 'timer':
 				if (event.target.value === 'custom') {

--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -214,6 +214,7 @@ class BlockForm extends Component {
 								placeholder="Time in mins"
 								type="number"
                                 min="1"
+								max="525600"
 								value={this.state.customTimer}
 								onChange={this.handleChange}
 							/>

--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -128,17 +128,16 @@ class BlockForm extends Component {
 		switch (event.target.name) {
 			case 'title':
 				let title = event.target.value;
-                const EMPTY_FIELD_CHECK = title.trim() === '';
-				titleValid = !EMPTY_FIELD_CHECK ?  'valid' : 'Title cannot be empty';
+                const EMPTY_FIELD = title.trim() === '';
+				titleValid = !EMPTY_FIELD ? 'valid' : 'Title cannot be empty';
+				break;
+			case 'customTimer':
+                const CUSTOM_TIMER_LENGTH = event.target.value >= 1 && event.target.value <= 1440;
+                timerValid = CUSTOM_TIMER_LENGTH ? 'valid' : 'Please select a time between 1 and 1440';
 				break;
 			case 'timer':
-				if (event.target.value === 'custom') {
-					timerValid = 'valid';
-				} else {
-					let timerLen = event.target.value.length;
-					timerValid = timerLen > 0 ? 'valid' : 'Please select a time';
-				}
-
+				let timerLen = event.target.value.length;
+				timerValid = timerLen > 0 ? 'valid' : 'Please select a time';
 				break;
 			case 'contact':
 				let validContact = event.target.value.match(
@@ -214,8 +213,6 @@ class BlockForm extends Component {
 								name="customTimer"
 								placeholder="Time in mins"
 								type="number"
-                                min="1"
-								max="525600"
 								value={this.state.customTimer}
 								onChange={this.handleChange}
 							/>

--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -128,7 +128,7 @@ class BlockForm extends Component {
 		switch (event.target.name) {
 			case 'title':
 				let title = event.target.value;
-                const EMPTY_FIELD_CHECK = title.trim() === "";
+                const EMPTY_FIELD_CHECK = title.trim() === '';
 				titleValid = !EMPTY_FIELD_CHECK ?  'valid' : 'Title cannot be empty';
 				break;
 			case 'timer':

--- a/focus-block/src/Components/BlockForm/BlockForm.js
+++ b/focus-block/src/Components/BlockForm/BlockForm.js
@@ -244,6 +244,7 @@ class BlockForm extends Component {
 						{this.props.isEditing ? (
 							<div className="action-buttons">
 								<button
+                                    type="button"
 									className="action-delete"
 									onClick={() => this.props.focusBlock.delete()}
 								>
@@ -253,6 +254,7 @@ class BlockForm extends Component {
 									/>
 								</button>
 								<button
+                                    type="button"
 									className="action-cancel"
 									onClick={() =>
 										this.props.focusBlock.setState({


### PR DESCRIPTION
- [x] User can enter blank title:
Fixed by trimming the inserted value and seeing if it contains any text, fairly simple.

- [x] User can enter custom unchecked time. (e.g., -10, 0, 111111111111111111111111):
Fixed by adding basic HTML form min and max values. The only two downsides I see to this is the form validation style now looks completely different to the style you originally created potentially causing confusion and the max value the user can insert has been restricted to 1 year, not sure how you feel about that but seems sensible in the grand scheme of things.

- [x] When editing focus block title. pressing enter defaults to delete prompt. bad UX:
Another simple fix, both the delete and cancel buttons did not have a type attribute causing the form to default to the first button in the form when the user pressed the enter key.

- [x] When time is too great, countdown timer does not work when clicking gets focused - This has been inherently fixed via the 2nd bug I spoke about above.

Thanks